### PR TITLE
fix removed udent

### DIFF
--- a/Formula/palm-os-sdk.rb
+++ b/Formula/palm-os-sdk.rb
@@ -40,7 +40,7 @@ class PalmOsSdk < Formula
     ln_s "#{prefix}/sdk-5r3", "#{HOMEBREW_PREFIX}/opt/prc-tools/palmdev/sdk-5r3"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     The Palm OS SDK files have been installed. Please run
 
         palmdev-prep

--- a/Formula/pilot-link.rb
+++ b/Formula/pilot-link.rb
@@ -58,7 +58,7 @@ class PilotLink < Formula
     system "make", "-C", "doc/man", "install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     All pilot-link commands (such as pilot-xfer) require a port argument (-p).
     On OS X, the correct port is "usb:" (note the trailing colon). As an
     example, you would use the following command to list the databases on the

--- a/Formula/prc-tools.rb
+++ b/Formula/prc-tools.rb
@@ -52,7 +52,7 @@ class PrcTools < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     prc-tools is now installed. Please install Palm OS SDK in
 
         #{opt_prefix}/palmdev


### PR DESCRIPTION
Homebrew removed udent.

Changes fix this bug:

```
$ brew install pilot-link
Updating Homebrew...
==> Installing pilot-link from jichu4n/palm-os
==> Downloading https://github.com/jichu4n/pilot-link/archive/0.12.5.tar.gz
==> Downloading from https://codeload.github.com/jichu4n/pilot-link/tar.gz/0.12.5
######################################################################## 100.0%
==> Downloading https://raw.githubusercontent.com/jichu4n/pilot-link/master/libpng14.patch
######################################################################## 100.0%
==> Patching
==> Applying libpng14.patch
patching file src/pilot-read-notepad.c
patching file src/pilot-read-palmpix.c
patching file src/pilot-read-screenshot.c
patching file src/pilot-read-veo.c
==> ./configure --prefix=/usr/local/Cellar/pilot-link/0.12.5 --libexecdir=/usr/local/Cellar/pilot-link/0.12.5/libexec --mandir=/usr/loca
==> make install
==> make -C doc/man install
Error: undefined method `undent' for #<String:0x0000000103a3edd8>
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Taps/jichu4n/homebrew-palm-os/Formula/pilot-link.rb:74:in `caveats'
/usr/local/Homebrew/Library/Homebrew/caveats.rb:17:in `caveats'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/lib/ruby/2.3.0/forwardable.rb:202:in `empty?'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:605:in `caveats'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:656:in `finish'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:330:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:259:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:257:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:257:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:89:in `<main>'
```